### PR TITLE
update some dependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
 *.gif
+test.md
+Dockerfile

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
 	"homepage": "https://github.com/gaurav-nelson/asciidoc-link-check#readme",
 	"dependencies": {
 		"asciidoc-link-extractor": ">=1.0.3",
-		"async": ">=3.2.0",
+		"async": ">=3.2.4",
 		"axios": ">=0.21.1",
 		"chalk": "^4.1.0",
 		"commander": ">=7.0.0",
-		"link-check": ">=4.5.4",
-		"lodash": ">=4.17.20",
+		"link-check": ">=5.2.0",
+		"lodash": ">=4.17.21",
 		"progress": "^2.0.3"
 	},
 	"devDependencies": {
-		"jshint": "^2.12.0"
+		"jshint": "^2.13.6"
 	}
 }


### PR DESCRIPTION
Hi,
This will update the link-check dependency, which previously used a deprecated `uuid` version

also few updates to `.npmignore`

```
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

└─┬ asciidoc-link-check@1.0.15
  └─┬ link-check@4.5.4
    └─┬ request@2.88.2
      └── uuid@3.4.0
```