### PR TITLE
Fix TypeError: program.option is not a function

### DIFF
--- a/asciidoc-link-check
+++ b/asciidoc-link-check
@@ -5,7 +5,7 @@
 const chalk = require("chalk");
 const fs = require("fs");
 const asciidocLinkCheck = require("./");
-const program = require("commander");
+const { program } = require("commander");
 const axios = require("axios");
 const url = require("url");
 const path = require("path");


### PR DESCRIPTION
Fixes #37 

This is a similar fix to https://github.com/SAP/spartacus/issues/10327
I don't understand why I'm unable to reproduce the problem locally in asciidoc-link-checker repo and only when using the repo as a pre-commit hook in another repo, but this change appears to fix the error in pre-commit. 

The functionality of this change is demonstrated in two github action runs
a. error (TypeError: program.option is not a function) before this change https://github.com/marcindulak/asciidoc-link-check-37/actions/runs/8121376916
b. success (error due to a dead link) using this change https://github.com/marcindulak/asciidoc-link-check-37/actions/runs/8121382475